### PR TITLE
Replace maps package with our own code

### DIFF
--- a/source/ucp-backend/go.mod
+++ b/source/ucp-backend/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.178 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mmcloughlin/geohash v0.10.0 // indirect
-	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 )

--- a/source/ucp-backend/go.sum
+++ b/source/ucp-backend/go.sum
@@ -18,8 +18,6 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
-golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/source/ucp-backend/src/business-logic/usecase/admincase.go
+++ b/source/ucp-backend/src/business-logic/usecase/admincase.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"log"
 	"strings"
-
-	"golang.org/x/exp/maps"
 )
 
 const IndustryConnectorPrefix = "travel-and-hospitality-connector"
@@ -233,15 +231,15 @@ func updateTaggedConnectors(taggedConnectorString, newConnector string) (string,
 // Convert colon separated list of connectors to an array of business objects
 func tagToObjects(tag string) []string {
 	taggedConnectors := strings.Split(tag, ":")
-	objects := make(map[string]string)
+	objects := make(map[string]struct{})
 	for _, v := range taggedConnectors {
 		connectorObjects := connectorMap[v]
 		for _, v := range connectorObjects {
-			objects[v] = ""
+			objects[v] = struct{}{}
 		}
 	}
 
-	return maps.Keys(objects)
+	return getKeys(objects)
 }
 
 func AddConnectorBucketToJobs(glueClient glue.Config, bucketName string, jobNames []string) error {
@@ -255,4 +253,12 @@ func AddConnectorBucketToJobs(glueClient glue.Config, bucketName string, jobName
 		}
 	}
 	return nil
+}
+
+func getKeys(m map[string]struct{}) []string {
+	keys := []string{}
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
Replace maps package with our own implementation of `getKeys()`

Change the map type to [string]struct{} - using the empty struct object which uses 0 bytes of memory and a recommended approach to recreating a `Set` object. 